### PR TITLE
RegexURLPattern __init__ method broken on Django 1.4

### DIFF
--- a/utkik/dispatch.py
+++ b/utkik/dispatch.py
@@ -110,7 +110,7 @@ class RegexURLPattern(urlresolvers.RegexURLPattern):
         We just changed the way the callback references are set compared to
         ``django.core.urlresolvers.RegexURLPattern.__init__``.
         """
-        self.regex = re.compile(regex, re.UNICODE)
+        self._regex = re.compile(regex, re.UNICODE)
         self._callback = callback
         self.default_args = default_args or {}
         self.name = name


### PR DESCRIPTION
The `RegexURLPattern` class tries to set the `regex` property, but in Django 1.4. regex is a read-only property due to the new locale/tz features. Changed to `_regex`, the actual property to set.
